### PR TITLE
Clear empty vertex groups

### DIFF
--- a/albam_reloaded/__init__.py
+++ b/albam_reloaded/__init__.py
@@ -17,7 +17,7 @@ bl_info = {
     "blender": (2, 80, 0),
     "location": "Properties Panel",
     "description": "Import-Export multiple video-game formats",
-    #"wiki_url": "https://github.com/Brachi/albam",
+    "wiki_url": "https://github.com/HenryOfCarim/albam_reloaded/wiki",
     "tracker_url": "https://github.com/HenryOfCarim/albam_reloaded/issues",
     "category": "Import-Export"}
 
@@ -33,6 +33,7 @@ classes = ( AlbamImportedItem,
             AlbamImportOperator,
             AlbamFixLeakedTexuresOperator,
             AlbamSelectInvalidMeshesOperator,
+            AlbamRemoveEmptyVertexGroupsOperator,
            )
 
 def register():

--- a/albam_reloaded/__init__.py
+++ b/albam_reloaded/__init__.py
@@ -24,6 +24,7 @@ bl_info = {
 
 classes = ( AlbamImportedItem,
             AlbamImportedItemName,
+            AlbamExportSettings,
             ALBAM_PT_CustomTextureOptions,
             AlbamExportOperator,
             ALBAM_PT_ImportExportPanel,
@@ -71,6 +72,7 @@ def register():
     bpy.types.Scene.albam_item_to_export = bpy.props.StringProperty()
     bpy.types.Scene.albam_items_imported = bpy.props.CollectionProperty(type=blender.AlbamImportedItemName) # register name property for scene
     bpy.types.Object.albam_imported_item = bpy.props.PointerProperty(type=blender.AlbamImportedItem) # register new object properties
+    bpy.types.Scene.albam_export_settings = bpy.props.PointerProperty(type=blender.AlbamExportSettings)
 
 def unregister():
     ''' Classic blender 2.80 unregistration of classes'''
@@ -81,6 +83,7 @@ def unregister():
     del bpy.types.Scene.albam_item_to_export 
     del bpy.types.Scene.albam_items_imported
     del bpy.types.Object.albam_imported_item
+    del bpy.types.Scene.albam_export_settings
 
 if __name__ == "__main__":
     register()

--- a/albam_reloaded/blender.py
+++ b/albam_reloaded/blender.py
@@ -26,6 +26,15 @@ class AlbamImportedItem(bpy.types.PropertyGroup):
     file_type : bpy.props.StringProperty(options={'HIDDEN'})
 
 
+class AlbamExportSettings(bpy.types.PropertyGroup):
+    '''Export option checkboxes for the Albam panel'''
+    export_visible_bool : bpy.props.BoolProperty(
+        name="Enable or Disable",
+        description="Export visible meshes only",
+        default = False
+        )
+
+
 class ALBAM_PT_CustomMaterialOptions(bpy.types.Panel):
     '''Custom Properies panel in the Material section'''
     bl_label = "Albam material"
@@ -63,7 +72,7 @@ class ALBAM_PT_CustomMaterialOptions(bpy.types.Panel):
 
 
 class ALBAM_PT_CustomTextureOptions(bpy.types.Panel):
-    "Custom Propertis panel for texures"
+    '''Custom Propertis panel for texures'''
     bl_label = "Albam texture"
     bl_space_type = 'PROPERTIES'
     bl_region_type = 'WINDOW'
@@ -87,7 +96,7 @@ class ALBAM_PT_CustomTextureOptions(bpy.types.Panel):
 
 
 class ALBAM_PT_CustomMeshOptions(bpy.types.Panel):
-    "Custom Propertis panel for meshes"
+    '''Custom Propertis panel for meshes'''
     bl_label = "[Albam] MTFramework Mesh Options"
     bl_space_type = 'PROPERTIES'
     bl_region_type = 'WINDOW'
@@ -120,9 +129,12 @@ class ALBAM_PT_ImportExportPanel(ALBAM_PT_View3DPanel, bpy.types.Panel):
     def draw(self, context):  # pragma: no cover
         scn = context.scene
         layout = self.layout
+        export_settings = scn.albam_export_settings
+
         layout.operator('albam_import.item', text='Import')
         layout.prop_search(scn, 'albam_item_to_export', scn, 'albam_items_imported', text='select')
         layout.operator('albam_export.item', text='Export')
+        layout.prop(export_settings, "export_visible_bool", text="Export visible meshes only ")
 
 class ALBAM_PT_ToolsPanel(ALBAM_PT_View3DPanel, bpy.types.Panel):
     '''UI Tool subpanel in 3D view'''
@@ -154,7 +166,6 @@ class AlbamImportOperator(bpy.types.Operator):
     def execute(self, context):
         to_import = [os.path.join(self.directory, f.name) for f in self.files] # combine path to file and file name list to a new list
         for file_path in to_import:
-            #print('file path is {}'.format(file_path))
             self._import_file(file_path=file_path, context=context)
 
         return {'FINISHED'}
@@ -179,7 +190,6 @@ class AlbamImportOperator(bpy.types.Operator):
             obj.albam_imported_item.source_path = str(file_path)
             
             # TODO: proper logging/raising and rollback if failure
-
             results_dict = func(blender_object=obj, **kwargs)
             #bpy.context.scene.objects.link(obj) #old
             bpy.context.collection.objects.link(obj)
@@ -279,7 +289,6 @@ class AlbamRemoveEmptyVertexGroupsOperator(bpy.types.Operator):
         scene_meshes = [obj for obj in selection if obj.type == 'MESH']
 
         for ob in scene_meshes:
-            #ob = context.object #bpy.data.objects['doom_armor_chest']
             ob.update_from_editmode()
             
             vgroup_used = {i: False for i, k in enumerate(ob.vertex_groups)}
@@ -292,6 +301,5 @@ class AlbamRemoveEmptyVertexGroupsOperator(bpy.types.Operator):
             for i, used in sorted(vgroup_used.items(), reverse=True):
                 if not used:
                     ob.vertex_groups.remove(ob.vertex_groups[i])
-            print(ob.name)
         show_message_box(message="Removing complete")
         return {'FINISHED'}

--- a/albam_reloaded/engines/mtframework/blender_export.py
+++ b/albam_reloaded/engines/mtframework/blender_export.py
@@ -132,11 +132,18 @@ def export_mod156(parent_blender_object):
 
     first_children = [child for child in parent_blender_object.children]
     blender_meshes = [c for c in first_children if c.type == 'MESH']
+    if (bpy.context.scene.albam_export_settings.export_visible_bool == True):
+        visible_meshes = [mesh for mesh in blender_meshes if mesh.mesh.visible_get()]
+        blender_meshes = visible_meshes
+
 
     # only going one level deeper
     if not blender_meshes:
         children_objects = list(chain.from_iterable(child.children for child in first_children))
         blender_meshes = [c for c in children_objects if c.type == 'MESH']
+        if (bpy.context.scene.albam_export_settings.export_visible_bool == True):
+            visible_meshes = [mesh for mesh in blender_meshes if mesh.visible_get()]
+            blender_meshes = visible_meshes
 
     if saved_mod.bone_count:
         bone_palettes = _create_bone_palettes(blender_meshes)

--- a/albam_reloaded/engines/mtframework/tools.py
+++ b/albam_reloaded/engines/mtframework/tools.py
@@ -67,7 +67,10 @@ def select_invalid_meshes_operator(scene_meshes):
         if armature:
             vertex_group_mapping = {vg.index: armature.pose.bones.find(vg.name) for vg in mesh.vertex_groups}
             vertex_group_mapping = {k: v for k, v in vertex_group_mapping.items() if v != -1}
-            bone_indices = {vertex_group_mapping[vgroup.group] for vertex in mesh.data.vertices for vgroup in vertex.groups}
+            try:
+                bone_indices = {vertex_group_mapping[vgroup.group] for vertex in mesh.data.vertices for vgroup in vertex.groups}
+            except:
+                print(mesh.name)
             if len(bone_indices)>32:
                 invalid_meshes.append(mesh)
         else:
@@ -78,5 +81,6 @@ def select_invalid_meshes_operator(scene_meshes):
             mesh.hide_select = False
             mesh.select_set(True)
             #bpy.context.view_layer.objects.active = mesh
+        show_message_box(message="Meshes with more than 32 bone influences selected")
     else:
         show_message_box(message="There is no invalid mesh")


### PR DESCRIPTION
- add a temporary tool for clearing empty vertex groups that cause an error on export
- add an option to export only visible  meshes