### PR TITLE
Implement shader node group instead of previous material implementation

### DIFF
--- a/albam_reloaded/engines/mtframework/blender_export.py
+++ b/albam_reloaded/engines/mtframework/blender_export.py
@@ -677,15 +677,13 @@ def _export_textures_and_materials(blender_objects, saved_mod):
                 continue
             setattr(material_data, attr_name, getattr(mat, attr_name))
 
-        ''' Old code    
-        for texture_slot in mat.texture_slots:
-            if not texture_slot or not texture_slot.texture:
-                continue
-            texture = texture_slot.texture
-            # texture_indices expects index-1 based
-            texture_index = textures.index(texture) + 1'''
+        #shader_node = mat.node_tree.nodes.get("MTFrameworkGroup")
+        #socket_name = shader_node.inputs[0].name
+        #is_linked = shader_node.inputs['Diffuse BM'].is_linked
+        #node_connected = shader_node.inputs['Diffuse BM'].node
 
         mat_tex = get_textures_from_the_material(mat) # get list with all ImageTexture nodes of the material
+        
         for texture_node in mat_tex:
             if not texture_node or not texture_node.image:
                 continue

--- a/albam_reloaded/engines/mtframework/blender_export.py
+++ b/albam_reloaded/engines/mtframework/blender_export.py
@@ -695,6 +695,8 @@ def _export_textures_and_materials(blender_objects, saved_mod):
                 raise ExportError("No texture data container linked with {} texture was found. Please create it before the export ".format(texture))
 
             texture_code = blender_texture_to_texture_code(texture_node)
+            if texture_code is None:
+                continue
             material_data.texture_indices[texture_code] = texture_index
         materials_data_array[mat_index] = material_data
         materials_mapping[mat.name] = mat_index

--- a/albam_reloaded/engines/mtframework/blender_import.py
+++ b/albam_reloaded/engines/mtframework/blender_import.py
@@ -461,7 +461,9 @@ def _create_blender_materials_from_mod(mod, model_name, textures):
         shader_node_group = blender_material.node_tree.nodes.new('ShaderNodeGroup')
         shader_node_group.node_tree = bpy.data.node_groups["MT Framework shader"]
         shader_node_group.name = "MTFrameworkGroup"
+        shader_node_group.width = 300
         material_output = blender_material.node_tree.nodes.get("Material Output")
+        material_output.location = (400, 0)
 
         link = blender_material.node_tree.links.new
         link(shader_node_group.outputs[0], material_output.inputs[0])

--- a/albam_reloaded/engines/mtframework/blender_import.py
+++ b/albam_reloaded/engines/mtframework/blender_import.py
@@ -261,10 +261,189 @@ def _create_blender_textures_from_mod(mod, base_dir):
 
     return textures
 
+def _create_shader_node_group():
+    shader_group = bpy.data.node_groups.new("MT Framework shader", 'ShaderNodeTree')
+
+    group_inputs = shader_group.nodes.new('NodeGroupInput')
+    group_inputs.location = (-2000,-200)
+
+    # Create group inputs
+    shader_group.inputs.new('NodeSocketColor',"Diffuse BM")
+    shader_group.inputs.new('NodeSocketFloat', "Alpha BM")
+    shader_group.inputs.new('NodeSocketColor','Normal NM')
+    shader_group.inputs.new('NodeSocketFloat',"Alpha NM")
+    shader_group.inputs.new('NodeSocketColor',"Specular MM")
+    shader_group.inputs.new('NodeSocketColor',"Lightmap LM")
+    shader_group.inputs.new('NodeSocketInt',"Use Lightmap")
+    shader_group.inputs["Use Lightmap"].min_value = 0
+    shader_group.inputs["Use Lightmap"].max_value = 1
+    shader_group.inputs.new('NodeSocketColor',"Alpha Mask AM")
+    shader_group.inputs.new('NodeSocketInt',"Use Alpha Mask")
+    shader_group.inputs["Use Alpha Mask"].min_value = 0
+    shader_group.inputs["Use Alpha Mask"].max_value = 1
+    shader_group.inputs.new('NodeSocketColor',"Environment CM")
+    shader_group.inputs.new('NodeSocketColor',"Detail NM")
+    shader_group.inputs.new('NodeSocketFloat',"Alpha NM")
+    shader_group.inputs.new('NodeSocketInt',"Use Detail Map")
+    shader_group.inputs["Use Detail Map"].min_value = 0
+    shader_group.inputs["Use Detail Map"].max_value = 1
+
+    # Create group outputs
+    group_outputs = shader_group.nodes.new('NodeGroupOutput')
+    group_outputs.location = (300,-90)
+    shader_group.outputs.new('NodeSocketShader','Surface')
+
+    # Shader node
+    bsdf_shader = shader_group.nodes.new('ShaderNodeBsdfPrincipled')
+    bsdf_shader.location = (0,-90)
+
+    # Mix a diffuse map and a lightmap
+    multiply_diff_light =  shader_group.nodes.new('ShaderNodeMixRGB')
+    multiply_diff_light.name = "mult_diff_and_light"
+    multiply_diff_light.label = "Multiply with Lightmap"
+    multiply_diff_light.blend_type = 'MULTIPLY'
+    multiply_diff_light.location = (-450, -100)
+
+    # RGB nodes
+    normal_separate = shader_group.nodes.new('ShaderNodeSeparateRGB')
+    normal_separate.name = "separate_normal"
+    normal_separate.label = "Separate Normal"
+    normal_separate.location =(-1700, -950)
+
+    normal_combine = shader_group.nodes.new('ShaderNodeCombineRGB')
+    normal_combine.name = "combine_normal"
+    normal_combine.label = "Combine Normal"
+    normal_combine.location = (-1500, -900)
+
+    detail_separate = shader_group.nodes.new('ShaderNodeSeparateRGB')
+    detail_separate.name = "separate_detail"
+    detail_separate.label = "Separate Detail"
+    detail_separate.location = (-1700,-1100)
+
+    detail_combine = shader_group.nodes.new('ShaderNodeCombineRGB')
+    detail_combine.name = "combine_detail"
+    detail_combine.label = "Combine Detail"
+    detail_combine.location = (-1500, -1050)
+
+    separate_rgb_n = shader_group.nodes.new('ShaderNodeSeparateRGB')
+    separate_rgb_n.name = "separate_rgb_n"
+    separate_rgb_n.label = "Separate RGB N"
+    separate_rgb_n.location = (-1250, -1050)
+
+    separate_rgb_d = shader_group.nodes.new('ShaderNodeSeparateRGB')
+    separate_rgb_d.name = "separate_rgb_d"
+    separate_rgb_d.label = "Separate RGB D"
+    separate_rgb_d.location = (-1250, -1250)
+
+    combine_all_normals = shader_group.nodes.new('ShaderNodeCombineRGB')
+    combine_all_normals.name = "combine_all_normals"
+    combine_all_normals.label = "Combine All Normals"
+    combine_all_normals.location = (-750, -1150)
+
+    # Normalize normals nodes
+    normalize_normals = shader_group.nodes.new('ShaderNodeVectorMath')
+    normalize_normals.operation = 'NORMALIZE'
+    normalize_normals.name = "normalize_normals"
+    normalize_normals.label = "Normalize Normals"
+    normalize_normals.location = (-590, -1050)
+
+    # Add nodes
+    add_normals_red = shader_group.nodes.new('ShaderNodeMixRGB')
+    add_normals_red.blend_type = 'ADD'
+    add_normals_red.name = "add_normals_red"
+    add_normals_red.label = "Add Normals Red"
+    add_normals_red.location = (-1000, -980)
+
+    add_normals_green=  shader_group.nodes.new('ShaderNodeMixRGB')
+    add_normals_green.blend_type = 'ADD'
+    add_normals_green.name = "add_normals_green"
+    add_normals_green.label = "Add Normals Green"
+    add_normals_green.location = (-1000, -1200)
+
+    add_normals_blue = shader_group.nodes.new('ShaderNodeMixRGB')
+    add_normals_blue.blend_type = 'ADD'
+    add_normals_blue.name = "add_normals_blue"
+    add_normals_blue.label = "Add Normals Blue"
+    add_normals_blue.location = (-1000, -1420)
+
+    # Invert node
+    invert_spec = shader_group.nodes.new('ShaderNodeInvert')
+    invert_spec.location = (-200, -350)
+
+    # Normal node
+    normal_map =  shader_group.nodes.new('ShaderNodeNormalMap') # create normal map node
+    normal_map.location = (-200, -720)
+
+    # Logic gates
+    use_lightmap = shader_group.nodes.new('ShaderNodeMixRGB')
+    use_lightmap.name = "switch_lightmap"
+    use_lightmap.label = "Lightmap Switcher"
+    use_lightmap.location = (-200, -150)
+
+    use_alpha_mask = shader_group.nodes.new('ShaderNodeMixRGB')
+    use_alpha_mask.name = "switch_alpha_mask"
+    use_alpha_mask.label = "Alpha Mask Switcher"
+    use_alpha_mask.location = (-200, -500)
+
+    use_detail_map = shader_group.nodes.new('ShaderNodeMixRGB')
+    use_detail_map.name ="switch_detail_map"
+    use_detail_map.label = "Detail Mask Switcher"
+    use_detail_map.location = (-440, -825)
+
+    # Link nodes
+    link = shader_group.links.new
+
+    link(bsdf_shader.outputs[0], group_outputs.inputs[0])
+    link(group_inputs.outputs[0], multiply_diff_light.inputs[1])
+    link(multiply_diff_light.outputs[0], use_lightmap.inputs[2])
+    link(group_inputs.outputs[0], use_lightmap.inputs[1])
+    link(use_lightmap.outputs[0], bsdf_shader.inputs[0])
+    link(group_inputs.outputs[1], use_alpha_mask.inputs[1])
+    link(use_alpha_mask.outputs[0], bsdf_shader.inputs[21])
+    link(group_inputs.outputs[2], normal_separate.inputs[0])
+    link(normal_separate.outputs[1], normal_combine.inputs[1])
+    link(normal_separate.outputs[2], normal_combine.inputs[2])
+    link(group_inputs.outputs[3], normal_combine.inputs[0])
+    link(normal_combine.outputs[0], use_detail_map.inputs[1])
+    link(normal_combine.outputs[0], separate_rgb_n.inputs[0])
+
+    link(group_inputs.outputs[4], invert_spec.inputs[1])
+    link(invert_spec.outputs[0], bsdf_shader.inputs[9])
+    link(group_inputs.outputs[5], multiply_diff_light.inputs[2])
+    link(group_inputs.outputs[6], use_lightmap.inputs[0])
+    link(group_inputs.outputs[7], use_alpha_mask.inputs[2]) # use alpha mask > color 2
+    link(group_inputs.outputs[8], use_alpha_mask.inputs[0]) # use alpha mask int
+
+    link(group_inputs.outputs[10], detail_separate.inputs[0])
+    link(group_inputs.outputs[11], detail_combine.inputs[0])
+    link(detail_separate.outputs[1], detail_combine.inputs[1])
+    link(detail_separate.outputs[2], detail_combine.inputs[2])
+    link(detail_combine.outputs[0], separate_rgb_d.inputs[0])
+
+    link(separate_rgb_n.outputs[0], add_normals_red.inputs[1])
+    link(separate_rgb_d.outputs[0], add_normals_red.inputs[2])
+    link(separate_rgb_n.outputs[1], add_normals_green.inputs[1])
+    link(separate_rgb_d.outputs[1], add_normals_green.inputs[2])
+    link(separate_rgb_n.outputs[2], add_normals_blue.inputs[1])
+    link(separate_rgb_d.outputs[2], add_normals_blue.inputs[2])
+    link(add_normals_red.outputs[0], combine_all_normals.inputs[0])
+    link(add_normals_green.outputs[0], combine_all_normals.inputs[1])
+    link(add_normals_blue.outputs[0], combine_all_normals.inputs[2])
+
+    link(combine_all_normals.outputs[0],normalize_normals.inputs[0])
+    link(normalize_normals.outputs[0],use_detail_map.inputs[2])
+    link(use_detail_map.outputs[0], normal_map.inputs[1])
+    link(normal_map.outputs[0], bsdf_shader.inputs[22])
+
+    return shader_group
+
 
 def _create_blender_materials_from_mod(mod, model_name, textures):
     '''textures: bpy.data.textures'''
     materials = []
+    if not bpy.data.node_groups.get("MT Framework shader"):
+        shader_node = _create_shader_node_group()
+
     for i, material in enumerate(mod.materials_data_array):
         blender_material = bpy.data.materials.new('{}_{}'.format(model_name, str(i).zfill(2)))
         blender_material.use_nodes = True
@@ -272,12 +451,6 @@ def _create_blender_materials_from_mod(mod, model_name, textures):
 
         principled_node = blender_material.node_tree.nodes.get("Principled BSDF")
         principled_node.inputs['Specular'].default_value = 0.2 # change specular
-
-        ''' Old code
-        #blender_material.use_transparency = True 
-        #blender_material.alpha = 0.0
-        #blender_material.specular_intensity = 0.2  # would be nice to get this info from the mod
-        '''
 
         # unknown data for export, registered already
         # TODO: do this with a util function

--- a/albam_reloaded/engines/mtframework/blender_import.py
+++ b/albam_reloaded/engines/mtframework/blender_import.py
@@ -285,8 +285,8 @@ def _create_shader_node_group():
     shader_group.inputs["Use Alpha Mask"].min_value = 0
     shader_group.inputs["Use Alpha Mask"].max_value = 1
     shader_group.inputs.new('NodeSocketColor',"Environment CM")
-    shader_group.inputs.new('NodeSocketColor',"Detail NM")
-    shader_group.inputs["Detail NM"].default_value = (1, 1, 1, 1)
+    shader_group.inputs.new('NodeSocketColor',"Detail DNM")
+    shader_group.inputs["Detail DNM"].default_value = (1, 1, 1, 1)
     shader_group.inputs.new('NodeSocketFloat',"Alpha DNM")
     shader_group.inputs["Alpha DNM"].default_value = 1
     shader_group.inputs.new('NodeSocketInt',"Use Detail Map")
@@ -454,6 +454,7 @@ def _create_blender_materials_from_mod(mod, model_name, textures):
         blender_material = bpy.data.materials.new('{}_{}'.format(model_name, str(i).zfill(2)))
         blender_material.use_nodes = True
         blender_material.blend_method = 'CLIP' # set transparency method 'OPAQUE', 'CLIP', 'HASHED', 'BLEND'
+        #blender_material.alpha_treshhold = 0.33
 
         node_to_delete = blender_material.node_tree.nodes.get("Principled BSDF")
         blender_material.node_tree.nodes.remove( node_to_delete )

--- a/albam_reloaded/engines/mtframework/mod_156.py
+++ b/albam_reloaded/engines/mtframework/mod_156.py
@@ -149,7 +149,7 @@ class MaterialData(Structure):
                 ('unk_flag_10', c_uint16, 1),
                 ('unk_flag_11', c_uint16, 1),
                 # Always set to zero since 8 bones is not yet supported
-                ('unk_flag_8_bones_vertex', c_uint16, 1),
+                ('flag_8_bones_vertex', c_uint16, 1),
                 ('unk_flag_12', c_uint16, 1),
                 ('unk_flag_13', c_uint16, 1),
                 ('unk_flag_14', c_uint16, 1),

--- a/albam_reloaded/engines/mtframework/utils.py
+++ b/albam_reloaded/engines/mtframework/utils.py
@@ -143,7 +143,11 @@ def texture_code_to_blender_texture(texture_code, blender_texture_node, blender_
     elif texture_code == 3:
         # Lightmap _LM
         blender_texture_node.location = (-300, -700)
-        link(blender_texture_node.outputs['Color'], principled_node.inputs[6])
+        uv_map_node = blender_material.node_tree.nodes.new('ShaderNodeUVMap')
+        uv_map_node.location = (-400, -700)
+        #uv_map_node.uv_map = [0]
+        link(blender_texture_node.outputs['Color'], principled_node.inputs[5])
+        principled_node.inputs[6].default_value = 1
 
     elif texture_code == 4:
         # Emissive mask ?
@@ -153,13 +157,32 @@ def texture_code_to_blender_texture(texture_code, blender_texture_node, blender_
         # Alpha mask _AM
         blender_texture_node.location = (-300, -1400)
         link(blender_texture_node.outputs['Color'], principled_node.inputs[7])
+        principled_node.inputs[8].default_value = 1
 
     elif texture_code == 7:
         #Detail normal map
         blender_texture_node.location = (-300, -1750)
+        tex_coord_node = blender_material.node_tree.nodes.new('ShaderNodeTexCoord') 
+        tex_coord_node.location = (-700, -1750)
+        mapping_node = blender_material.node_tree.nodes.new('ShaderNodeMapping')
+        mapping_node.location = (-500, -1750)
+
+        link(tex_coord_node.outputs[2], mapping_node.inputs[0])
+        link(mapping_node.outputs[0], blender_texture_node.inputs[0])
         link(blender_texture_node.outputs['Color'], principled_node.inputs[10])
         link(blender_texture_node.outputs['Alpha'], principled_node.inputs[11])
 
+        principled_node.inputs[12].default_value = 1
+        #TODO move it to function
+        #Link the material properites value
+        for x in range(3):
+            d = mapping_node.inputs[3].driver_add("default_value", x)
+            var1 = d.driver.variables.new()
+            var1.name = "detail_multiplier"
+            var1.targets[0].id_type = 'MATERIAL'
+            var1.targets[0].id = blender_material
+            var1.targets[0].data_path = '["unk_detail_factor"]'
+            d.driver.expression = var1.name
     else:
         print('texture_code not supported', texture_code)
         # TODO: 6 CM cubemap

--- a/albam_reloaded/engines/mtframework/utils.py
+++ b/albam_reloaded/engines/mtframework/utils.py
@@ -120,118 +120,49 @@ def texture_code_to_blender_texture(texture_code, blender_texture_node, blender_
         blender_material : shader material
     '''
     #blender_texture_node.use_map_alpha = True
-    principled_node = blender_material.node_tree.nodes.get('Principled BSDF')
+    principled_node = blender_material.node_tree.nodes.get("MTFrameworkGroup")
     link = blender_material.node_tree.links.new
 
     if texture_code == 0:
         # Diffuse _BM
-        link(blender_texture_node.outputs['Color'], principled_node.inputs['Base Color'])
-        link(blender_texture_node.outputs['Alpha'], principled_node.inputs['Alpha'])
+        link(blender_texture_node.outputs['Color'], principled_node.inputs[0])
+        link(blender_texture_node.outputs['Alpha'], principled_node.inputs[1])
         blender_texture_node.location =(-300, 350)
         #blender_texture_node.use_map_color_diffuse = True
     elif texture_code == 1:
         # Normal _NM
-        # Since normal maps have offset channels, they need to be rearranged for Blender
-        nm_separateRGB_n = blender_material.node_tree.nodes.new('ShaderNodeSeparateRGB')
-        nm_separateRGB_n.location =(-860, -550)
-        nm_combineRGB_n = blender_material.node_tree.nodes.new('ShaderNodeCombineRGB')
-        nm_combineRGB_n.location = (-670, -500)
-
-        blender_texture_node.location = (-1150, -450)
-        link(blender_texture_node.outputs['Color'], nm_separateRGB_n.inputs['Image'])
-        link(blender_texture_node.outputs['Alpha'], nm_combineRGB_n.inputs['R']) # set normal node to shader socket
-        link(nm_separateRGB_n.outputs['G'], nm_combineRGB_n.inputs['G'])
-        link(nm_separateRGB_n.outputs['B'], nm_combineRGB_n.inputs['B'])
-
-        dt_normal_n = blender_material.node_tree.nodes.get('Normal Map')
-        #If a detail map was created before normal map
-        if dt_normal_n:
-            print("see normal node from a detail map(?) on the normal creation")
-            dt_combineRGB_n = dt_normal_n.inputs['Color'].links[0].from_node
-            dt_mixRGB = blender_material.node_tree.nodes.new('ShaderNodeMixRGB')
-            dt_mixRGB.location = (-470, -250)
-            link(dt_combineRGB_n.outputs['Image'],dt_mixRGB.inputs['Color1'])
-            link(nm_combineRGB_n.outputs['Image'],dt_mixRGB.inputs['Color2'])
-            link(dt_mixRGB.outputs['Color'],dt_normal_n.inputs['Color'])
-        else:
-            normal_map_node = blender_material.node_tree.nodes.new("ShaderNodeNormalMap")
-            normal_map_node.location = (-200, -260)
-            link(nm_combineRGB_n.outputs['Image'], normal_map_node.inputs['Color'])
-
-        link(normal_map_node.outputs['Normal'], principled_node.inputs['Normal']) # set normal node to shader socket
+        blender_texture_node.location = (-300, 0)
+        link(blender_texture_node.outputs['Color'], principled_node.inputs[2])
+        link(blender_texture_node.outputs['Alpha'], principled_node.inputs[3])
 
     elif texture_code == 2:
         # Specular _MM
-        blender_texture_node.location = (-600, 60)
-        invert_spec_node = blender_material.node_tree.nodes.new('ShaderNodeInvert')
-        invert_spec_node.location = (-330, 60)
-
-        link(blender_texture_node.outputs['Color'], invert_spec_node.inputs['Color'])
-        link(invert_spec_node.outputs['Color'], principled_node.inputs['Roughness'])
-
+        blender_texture_node.location = (-300, -350)
+        link(blender_texture_node.outputs['Color'], principled_node.inputs[4])
+   
     elif texture_code == 3:
         # Lightmap _LM
-        blender_texture_node.location = (600, 100)
-        blender_texture_node.interpolation = 'Closest'
+        blender_texture_node.location = (-300, -700)
+        link(blender_texture_node.outputs['Color'], principled_node.inputs[6])
 
     elif texture_code == 4:
-        # Emissive mask _CM ?
-        blender_texture_node.location = (600, -300)
-        blender_texture_node.interpolation = 'Cubic'
+        # Emissive mask ?
+        blender_texture_node.location = (-300, -1050)
 
     elif texture_code == 5:
         # Alpha mask _AM
-        blender_texture_node.location = (600, -500)
-        blender_texture_node.interpolation = 'Smart'
+        blender_texture_node.location = (-300, -1400)
+        link(blender_texture_node.outputs['Color'], principled_node.inputs[7])
 
     elif texture_code == 7:
         #Detail normal map
-        blender_texture_node.location =(-1150, -130)
-        dt_tex_coord_n = blender_material.node_tree.nodes.new('ShaderNodeTexCoord') 
-        dt_tex_coord_n.location = (-1550, -340)
-        dt_mapping_n = blender_material.node_tree.nodes.new('ShaderNodeMapping')
-        dt_mapping_n.location = (-1350, -340)
+        blender_texture_node.location = (-300, -1750)
+        link(blender_texture_node.outputs['Color'], principled_node.inputs[10])
+        link(blender_texture_node.outputs['Alpha'], principled_node.inputs[11])
 
-        # link detail map multiplier to the custom material property
-        for x in range(3):
-            d = dt_mapping_n.inputs[3].driver_add("default_value", x)
-            var1 = d.driver.variables.new()
-            var1.name = "detail_multiplier"
-            var1.targets[0].id_type = 'MATERIAL'
-            var1.targets[0].id = blender_material
-            var1.targets[0].data_path = '["unk_detail_factor"]'
-            d.driver.expression = var1.name
-
-        
-        dt_separateRGB_n = blender_material.node_tree.nodes.new('ShaderNodeSeparateRGB')
-        dt_separateRGB_n.location = (-860, -260)
-        dt_combineRGB_n = blender_material.node_tree.nodes.new('ShaderNodeCombineRGB')
-        dt_combineRGB_n.location =(-670, -220)
-
-        link(dt_tex_coord_n.outputs['UV'], dt_mapping_n.inputs['Vector'])
-        link(dt_mapping_n.outputs['Vector'], blender_texture_node.inputs['Vector'])
-        
-        link(blender_texture_node.outputs['Color'], dt_separateRGB_n.inputs['Image'])
-        link(blender_texture_node.outputs['Alpha'], dt_combineRGB_n.inputs['R'])
-        link(dt_separateRGB_n.outputs['G'], dt_combineRGB_n.inputs['G'])
-        link(dt_separateRGB_n.outputs['B'], dt_combineRGB_n.inputs['B'])
-
-        nm_normal_n = blender_material.node_tree.nodes.get('Normal Map') # check if normal node is already exist
-        if nm_normal_n: # in case the normal map was created before a detail map
-            dt_mixRGB = blender_material.node_tree.nodes.new('ShaderNodeMixRGB')
-            dt_mixRGB.location = (-470, -250)
-            link(dt_combineRGB_n.outputs['Image'],dt_mixRGB.inputs['Color1'])
-            nm_combineRGB_n = nm_normal_n.inputs['Color'].links[0].from_node # get combine RGB link from the normal map inputs
-            link(dt_mixRGB.outputs['Color'],nm_normal_n.inputs['Color'])
-            link(nm_combineRGB_n.outputs['Image'], dt_mixRGB.inputs['Color2'])
-        else: 
-            dt_normal_n = blender_material.node_tree.nodes.new("ShaderNodeNormalMap") # create a new normal map node
-            dt_normal_n.location = (-200, -130)
-            link(dt_combineRGB_n.outputs['Image'], dt_normal_n.inputs['Color'])
-            link(dt_normal_n.outputs['Normal'], principled_node.inputs['Normal'])
     else:
         print('texture_code not supported', texture_code)
-        # TODO: 3, 4, 5, 6,
+        # TODO: 6 CM cubemap
 
 
 def blender_texture_to_texture_code(blender_texture_image_node):

--- a/albam_reloaded/engines/mtframework/utils.py
+++ b/albam_reloaded/engines/mtframework/utils.py
@@ -193,41 +193,27 @@ def blender_texture_to_texture_code(blender_texture_image_node):
     '''This function return a type ID of the image texture node dependind of node connetion
         blender_texture_image_node : bpy.types.ShaderNodeTexImage
     '''
-    texture_code = 0
+    texture_code = None
     color_out = blender_texture_image_node.outputs['Color']
     try:
         socket_name = color_out.links[0].to_socket.name
     except:
         print("the texture has no connections")
-    #socket_name = (color_out.links[0].to_node.from_socket.name)
+        return None
 
-    # Diffuse
-    if socket_name == "Diffuse BM":
-        texture_code = 0
+    tex_codes_mapper = {
+    'Diffuse BM': 0,
+    'Normal NM': 1,
+    'Specular MM': 2,
+    'Lightmap LM': 3,
+    'Alpha Mask AM': 5,
+    'Environment CM': 6,
+    'Detail DNM': 7
+    }
 
-    # Normal
-    elif socket_name == "Normal NM":
-        texture_code = 1
-
-    # Specular
-    elif socket_name == "Specular MM":
-        texture_code = 2
-
-    # Lightmap
-    elif socket_name == "Lightmap LM":
-        texture_code = 3
-    
-    # Alpha Mask
-    elif socket_name == "Alpha Mask AM":
-        texture_code = 5
-
-    # Alpha Mask
-    elif socket_name == "Environment CM":
-        texture_code = 6
-
-    # Detail normal map
-    elif socket_name == 'Detail DNM':
-        texture_code = 7
+    texture_code = tex_codes_mapper.get(socket_name)
+    if texture_code is None:
+        return None
 
     return texture_code
 


### PR DESCRIPTION
This shader node simplifies export and hides under the hood things that can confuse the user
![image](https://user-images.githubusercontent.com/18252816/182389938-7807b22f-142e-4cd8-b232-30f646f56558.png)
