### PR TITLE
Fix normal importing

### DIFF
--- a/albam_reloaded/engines/mtframework/blender_import.py
+++ b/albam_reloaded/engines/mtframework/blender_import.py
@@ -6,6 +6,7 @@ try:
     import bpy
     import addon_utils
     from mathutils import Matrix, Vector
+    import numpy as np
 except ImportError:
     pass
 
@@ -125,11 +126,10 @@ def _build_blender_mesh_from_mod(mod, mesh, mesh_index, name, materials):
     me_ob.update(calc_edges=True)
     me_ob.polygons.foreach_set("use_smooth", [True] * len(me_ob.polygons))
 
-    loop_normals = []
-    for loop in me_ob.loops:
-        loop_normals.append(vertex_normals[loop.vertex_index])
-
-    me_ob.normals_split_custom_set_from_vertices(vertex_normals)
+    vert_normals = np.array(vertex_normals, dtype=np.float32)
+    norms = np.linalg.norm(vert_normals, axis=1, keepdims=True)
+    np.divide(vert_normals, norms, out=vert_normals, where=norms != 0)
+    me_ob.normals_split_custom_set_from_vertices(vert_normals)
     me_ob.use_auto_smooth = True
 
     mesh_material = materials[mesh.material_index]


### PR DESCRIPTION
Fixes #5  Normalizes vectors before creating them. Otherwise, the final values stored in custom split normals won't match the ones from the original model.

Taken from glTF importer:
https://github.com/KhronosGroup/glTF-Blender-IO/blob/60b7e7e6bef2be83468e8bdd68463788e38ec170/addons/io_scene_gltf2/blender/imp/gltf2_blender_mesh.py#L646

By displaying split normals in the UI it can be checked that they the ones from the borders of meshes act as one.
Results look promising from a quick visual test. Note that this change affects not only model heads that have highly divided meshes, but all meshes.

I still need to check export code and verify that we get back the same values in a round trip import-export.


