### PR TITLE
Initial import/export support for uncompressed textures

### DIFF
--- a/albam_reloaded/image_formats/dds.py
+++ b/albam_reloaded/image_formats/dds.py
@@ -1,4 +1,4 @@
-from ctypes import Structure, sizeof, c_int, c_char, c_byte
+from ctypes import Structure, sizeof, c_int, c_char, c_ubyte
 import os
 
 from ..exceptions import TextureError
@@ -6,36 +6,7 @@ from ..lib.structure import DynamicStructure
 
 
 class DDSHeader(Structure):
-
-    _fields_ = (('id_magic', c_char * 4),
-                ('dwSize', c_int),
-                ('dwFlags', c_int),
-                ('dwHeight', c_int),
-                ('dwWidth', c_int),
-                ('dwPitchOrLinearSize', c_int),
-                ('dwDepth', c_int),
-                ('dwMipMapCount', c_int),
-                ('dwReserved1', c_int * 11),
-                ('pixelfmt_dwSize', c_int),
-                ('pixelfmt_dwFlags', c_byte * 4),
-                ('pixelfmt_dwFourCC', c_char * 4),
-                ('pixelfmt_dwRGBBitCount', c_int),
-                ('pixelfmt_dwRBitMask', c_int),
-                ('pixelfmt_dwGBitMask', c_int),
-                ('pixelfmt_dwBBitMask', c_int),
-                ('pixelfmt_dwABitMask', c_int),
-                ('dwCaps', c_int),
-                ('dwCaps2', c_int),
-                ('dwCaps3', c_int),
-                ('dwCaps4', c_int),
-                ('dwReserved2', c_int),
-                )
-
-
-class DDS(DynamicStructure):
-    # https://msdn.microsoft.com/en-us/library/windows/desktop/bb943982
-    # https://msdn.microsoft.com/en-us/library/windows/desktop/bb943984
-
+    # https://learn.microsoft.com/en-us/windows/win32/direct3ddds/dds-header
     DDSD_CAPS = 0x1
     DDSD_HEIGHT = 0x2
     DDSD_WIDTH = 0x4
@@ -58,50 +29,88 @@ class DDS(DynamicStructure):
     DDSCAPS2_CUBEMAP_NEGATIVEZ = 0x8000
     DDSCAPS2_VOLUME = 0x200000
 
+    DDPF_ALPHAPIXELS = 0x1
+    DDPF_FOURCC = 0x4
+    DDPF_RGB = 0x40
+
     REQUIRED_FLAGS = DDSD_CAPS | DDSD_HEIGHT | DDSD_WIDTH | DDSD_PIXELFORMAT
 
-    _fields_ = (('header', DDSHeader),
-                ('data', lambda s, f: c_byte * (os.path.getsize(f) - sizeof(s.header)) if f else c_byte * len(s.data)),
-                )
+    _fields_ = (
+        ("id_magic", c_char * 4),
+        ("dwSize", c_int),
+        ("dwFlags", c_int),
+        ("dwHeight", c_int),
+        ("dwWidth", c_int),
+        ("dwPitchOrLinearSize", c_int),
+        ("dwDepth", c_int),
+        ("dwMipMapCount", c_int),
+        ("dwReserved1", c_int * 11),
+        ("pixelfmt_dwSize", c_int),
+        ("pixelfmt_dwFlags", c_int),
+        ("pixelfmt_dwFourCC", c_char * 4),
+        ("pixelfmt_dwRGBBitCount", c_int),
+        ("pixelfmt_dwRBitMask", c_int),
+        ("pixelfmt_dwGBitMask", c_int),
+        ("pixelfmt_dwBBitMask", c_int),
+        ("pixelfmt_dwABitMask", c_int),
+        ("dwCaps", c_int),
+        ("dwCaps2", c_int),
+        ("dwCaps3", c_int),
+        ("dwCaps4", c_int),
+        ("dwReserved2", c_int),
+    )
 
-    # TODO: set this automatically on __init__
     def set_constants(self):
-        self.header.id_magic = b'DDS '
-        self.header.dwSize = 124
-        self.header.dwFlags = self.REQUIRED_FLAGS
+        self.id_magic = b"DDS "
+        self.dwSize = 124
+        self.dwFlags = self.REQUIRED_FLAGS
+        self.pixelfmt_dwSize = 32
+        self.dwCaps = self.DDSCAPS_TEXTURE
 
-        self.header.pixelfmt_dwSize = 32
+    def set_variables(self, compressed=True):
+        if not compressed:
+            self.dwPitchOrLinearSize = 0
+        else:
+            try:
+                self.dwPitchOrLinearSize = self.calculate_linear_size(
+                    self.dwWidth, self.dwHeight, self.pixelfmt_dwFourCC
+                )
+            except Exception as err:
+                print(f"failed to set dwPitchOrLinearSize: {err}")
 
-        self.header.pixelfmt_dwFlags = (c_byte * 4)(4, 0, 0, 0)
+        if self.dwMipMapCount:
+            self.dwFlags |= self.DDSD_MIPMAPCOUNT
+            self.dwCaps |= self.DDSCAPS_MIPMAP
+            self.dwCaps |= self.DDSCAPS_COMPLEX
+            # TODO: add 'or cubic or mipmapped_volume'
 
-        self.header.dwCaps = self.DDSCAPS_TEXTURE
-
-    def set_variables(self):
-        self.header.dwPitchOrLinearSize = self.calculate_linear_size(self.header.dwWidth,
-                                                                     self.header.dwHeight,
-                                                                     self.header.pixelfmt_dwFourCC)
-        if self.header.dwMipMapCount:
-            self.header.dwFlags |= self.DDSD_MIPMAPCOUNT
-            self.header.dwCaps |= self.DDSCAPS_MIPMAP
-        if self.header.dwMipMapCount:  # TODO: add 'or cubic or mipmapped_volume'
-            self.header.dwCaps |= self.DDSCAPS_COMPLEX
+        if compressed:
+            self.pixelfmt_dwFlags |= self.DDPF_FOURCC
+        else:
+            # specific for observed .tex in RE5 so far
+            self.pixelfmt_dwFlags |= self.DDPF_RGB
+            self.pixelfmt_dwFlags |= self.DDPF_ALPHAPIXELS  # TODO: need without alpha?
+            self.pixelfmt_dwRGBBitCount = 32
+            self.pixelfmt_dwRBitMask = 0xFF0000
+            self.pixelfmt_dwGBitMask = 0xFF00
+            self.pixelfmt_dwBBitMask = 0xFF
+            self.pixelfmt_dwABitMask = 0xFF000000
 
     @property
     def mipmap_sizes(self):
-        h = self.header.dwWidth
-        w = self.header.dwHeight
-        fmt = self.header.pixelfmt_dwFourCC
-        return [self.calculate_mipmap_size(w, h, i, fmt) for i in
-                range(self.header.dwMipMapCount)]
+        h = self.dwWidth
+        w = self.dwHeight
+        fmt = self.pixelfmt_dwFourCC
+        return [self.calculate_mipmap_size(w, h, i, fmt) for i in range(self.dwMipMapCount)]
 
     @staticmethod
     def get_block_size(fmt):
-        if fmt in (b'DXT1', b'BC1', b'BC4'):
+        if fmt in (b"DXT1", b"BC1", b"BC4"):
             return 8
-        elif fmt in (b'DXT3', b'DXT5'):
+        elif fmt in (b"DXT3", b"DXT5"):
             return 16
         else:
-            raise TextureError('Unrecognized format in dds: {}'.format(fmt))
+            raise TextureError("Unrecognized format in dds: {}".format(fmt))
 
     @classmethod
     def calculate_linear_size(cls, width, height, fmt):
@@ -121,11 +130,11 @@ class DDS(DynamicStructure):
             w >>= 1
         if h > 1:
             h >>= 1
-        if fmt == 'DDS_COMPRESS_NONE':
-            size += (w * h) * 16  # FIXME: get real bpp
+        if not fmt:
+            size += (w * h) * 4
         else:
             size += ((w + 3) // 4) * ((h + 3) // 4)
-            if fmt == b'DXT1' or fmt == b'DXT4':
+            if fmt == b"DXT1" or fmt == b"DXT4":
                 size *= 8
             else:
                 size *= 16
@@ -140,3 +149,9 @@ class DDS(DynamicStructure):
             count += 1
             size = size // 2
         return count
+
+class DDS(DynamicStructure):
+    _fields_ = (
+        ('header', DDSHeader),
+        ('data', lambda s, f: c_ubyte * (os.path.getsize(f) - sizeof(s.header)) if f else c_ubyte * len(s.data)),
+    )


### PR DESCRIPTION
Fixes #23 
Modify DDS structure to take into account number of images, unused for now, but useful for cubemaps soon.
Fix block size for uncompressed textures: each pixel is 4 bytes. Move methods from DDS to DDSHeader, since it's the only structure we care about.